### PR TITLE
Adding firewall cache

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -18,7 +18,7 @@ maintainer:
 summary: This resource pack provides helpers for the Google Cloud Platform Inspec profiles.
 copyright: Google
 copyright_email: copyright@google.com
-version: 1.0.7
+version: 1.0.8
 license: Apache-2.0
 inspec_version: '>= 4.7.3' 
 depends:

--- a/libraries/cloud_sql_cache.rb
+++ b/libraries/cloud_sql_cache.rb
@@ -28,6 +28,7 @@ class CloudSQLCache < GCPBaseCache
   @@cache_set = false
 
   def initialize(project: '')
+    super()
     @gcp_project_id = project
   end
 

--- a/libraries/fw_cache.rb
+++ b/libraries/fw_cache.rb
@@ -38,6 +38,7 @@ class FirewallCache < GCPBaseCache
   @@firewall_objects_cache_set = false
 
   def initialize(project: '')
+    super()
     @gcp_project_id = project
   end
 

--- a/libraries/fw_cache.rb
+++ b/libraries/fw_cache.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'gcp_base_cache'
+
+# Cache for VPC Firewalls.
+#
+class FirewallCache < GCPBaseCache
+  name 'FirewallCache'
+  desc 'The Firewall Cache stores a list of firewall names and their corresponding
+  google_compute_firewall objects in a hashmap
+
+  Usage:
+  fw_cache = FirewallCache(project: "project_name")
+
+  fw_cache.firewall_names
+  <prints list of firewall names>
+
+  fw_cache.firewall_objects["fw_name"]
+  <returns google_compute_firewall(project: "project_name", name: fw_name)>
+  '
+
+  @@cached_firewall_names = []
+  @@cached_firewall_objects = {}
+  @@firewall_names_cache_set = false
+  @@firewall_objects_cache_set = false
+
+  def initialize(project: '')
+    @gcp_project_id = project
+  end
+
+  def firewall_names
+    set_firewall_names_cache unless firewall_names_cache_set?
+    @@cached_firewall_names
+  end
+
+  def firewall_objects
+    set_firewall_objects_cache unless firewall_objects_cache_set?
+    @@cached_firewall_objects
+  end
+
+  def firewall_names_cache_set?
+    @@firewall_names_cache_set
+  end
+
+  def firewall_objects_cache_set?
+    @@firewall_objects_cache_set
+  end
+
+  private
+
+  def set_firewall_names_cache
+    @@cached_firewall_names =
+      inspec.google_compute_firewalls(project: @gcp_project_id)
+            .firewall_names
+    @@firewall_names_cache_set = true
+  end
+
+  def set_firewall_objects_cache
+    @@cached_firewall_objects = {}
+
+    firewall_names.each do |firewall_name|
+      @@cached_firewall_objects[firewall_name] =
+        inspec.google_compute_firewall(project: @gcp_project_id,
+                                       name: firewall_name)
+    end
+    @@firewall_objects_cache_set = true
+  end
+end

--- a/libraries/gce_cache.rb
+++ b/libraries/gce_cache.rb
@@ -28,6 +28,7 @@ class GCECache < GCPBaseCache
   @@gce_instances_cached = false
 
   def initialize(project: '', gce_zones: [])
+    super()
     @gcp_project_id = project
     @gce_zones = if gce_zones.join.empty?
                    inspec.google_compute_zones(project: @gcp_project_id)

--- a/libraries/gcp_base_cache.rb
+++ b/libraries/gcp_base_cache.rb
@@ -24,6 +24,7 @@ class GCPBaseCache < Inspec.resource(1)
   attr_reader :gke_locations
 
   def initialize(project: '')
+    super()
     @gcp_project_id = project
     @gke_locations = []
   end

--- a/libraries/gke_cache.rb
+++ b/libraries/gke_cache.rb
@@ -28,6 +28,7 @@ class GKECache < GCPBaseCache
   @@gke_clusters_cached = false
 
   def initialize(project: '', gke_locations: [])
+    super()
     @gcp_project_id = project
     @gke_locations = if gke_locations.join.empty?
                        all_gcp_locations

--- a/libraries/iam_bindings_cache.rb
+++ b/libraries/iam_bindings_cache.rb
@@ -29,6 +29,7 @@ class IAMBindingsCache < GCPBaseCache
   @@iam_binding_roles_cache_set = false
 
   def initialize(project: '')
+    super()
     @gcp_project_id = project
   end
 

--- a/libraries/kms_key_cache.rb
+++ b/libraries/kms_key_cache.rb
@@ -31,6 +31,7 @@ class KMSKeyCache < GCPBaseCache
   @kms_locations = []
 
   def initialize(project: '', locations: [])
+    super()
     @gcp_project_id = project
     @kms_locations = locations
   end

--- a/libraries/service_accounts_cache.rb
+++ b/libraries/service_accounts_cache.rb
@@ -29,6 +29,7 @@ class ServiceAccountCache < GCPBaseCache
   @@sa_keys_cache_set = false
 
   def initialize(project: '')
+    super()
     @gcp_project_id = project
   end
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/issues/10

Implements a cache for VPC firewalls.

Usage: 
```
fw_cache = FirewallCache(project: "project_name")

fw_cache.firewall_names
<prints list of firewall names>

fw_cache.firewall_objects["fw_name"]
<returns google_compute_firewall(project: "project_name", name: fw_name)>
```
